### PR TITLE
remove .env from version control; event steward address is an environ…

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-# Don't delete me!

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Ignore all environment files.
 /.env*
+.env
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
                  <%= yield %>
                </main>
                <div class="p-md-5 p-sm-3 mb-0 footer">
-                Contact: <%= link_to "The event stewards", "mailto:cecilia@cynnabar.org" %>
+                 Contact: <%= link_to "The event stewards", "mailto:#{ENV["EVENT_STEWARD_EMAIL_ADDRESS"]}" %>
                 </div>
             </div>
             <div class="col-lg-2 secondary-bg"></div>

--- a/compose.yml
+++ b/compose.yml
@@ -20,8 +20,11 @@ services:
     depends_on:
       mariadb: *healthy
     command: bash -c "bundle exec rails s -b 0.0.0.0"
+    env_file:
+      - .env
     environment:
       - DB_HOST=mariadb
+
 
   dev:
     build:


### PR DESCRIPTION
This PR enables setting the event steward email address as an environment variable. This way a change to it does not require a deployment of the website code.

It also removes the .env file from version control. 